### PR TITLE
Added transparent backgroundcolor to webview widget

### DIFF
--- a/lib/src/mobile/high_chart.dart
+++ b/lib/src/mobile/high_chart.dart
@@ -132,6 +132,7 @@ class _HighChartsState extends State<HighCharts> {
             javascriptMode: JavascriptMode.unrestricted,
             zoomEnabled: false,
             initialMediaPlaybackPolicy: AutoMediaPlaybackPolicy.always_allow,
+            backgroundColor: Colors.transparent,
             onWebViewCreated: (WebViewController _) {
               _controller = _;
               _loadHtmlContent(_);


### PR DESCRIPTION
Adds parameter backgroundColor to webview widget, and sets it to Colors.transparent.

This is only a fix for mobile.