### PR TITLE
Fix crash

### DIFF
--- a/lib/src/mobile/high_chart.dart
+++ b/lib/src/mobile/high_chart.dart
@@ -172,10 +172,12 @@ class _HighChartsState extends State<HighCharts> {
   }
 
   void _loadData() {
-    setState(() {
-      _isLoaded = true;
-    });
-    _controller!.runJavascriptReturningResult(
-        "senthilnasa(`Highcharts.chart('highChartsDiv',${widget.data} )`);");
+    if (mounted) {
+      setState(() {
+        _isLoaded = true;
+      });
+      _controller!.runJavascriptReturningResult(
+          "senthilnasa(`Highcharts.chart('highChartsDiv',${widget.data} )`);");
+    }
   }
 }


### PR DESCRIPTION
Check if state is mounted to avoid call setState() after disposed